### PR TITLE
fix(typography): Muted, Lead and Small typography ignore muted foreground color documented in the docs

### DIFF
--- a/docs/foundations/typography.mdx
+++ b/docs/foundations/typography.mdx
@@ -63,10 +63,10 @@ import {
 | `H3` | `h3` | `text-2xl font-semibold` |
 | `H4` | `h4` | `text-xl font-semibold` |
 | `P` | `p` | `text-base leading-7` |
-| `Lead` | `p` | `text-lg leading-8` |
+| `Lead` | `p` | `text-lg text-text-muted leading-8` |
 | `Strong` | `p` | `text-base font-semibold leading-7` |
-| `Small` | `p` | `text-sm leading-6` |
-| `Muted` | `p` | `text-xs leading-5 text-text` |
+| `Small` | `p` | `text-sm text-text-muted leading-6` |
+| `Muted` | `p` | `text-xs leading-5 text-text-muted` |
 | `Code` | `code` | `text-sm font-mono bg-surface px-2 py-1 rounded` |
 | `Link` | `a` | `text-primary underline hover:no-underline` |
 | `Blockquote` | `blockquote` | `border-l-4 border-primary pl-4 italic` |

--- a/lib/components/foundations/typography.tsx
+++ b/lib/components/foundations/typography.tsx
@@ -58,7 +58,12 @@ export function Lead({
   className,
   ...props
 }: React.HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn("text-lg leading-8", className)} {...props} />;
+  return (
+    <p
+      className={cn("text-lg text-text-muted leading-8", className)}
+      {...props}
+    />
+  );
 }
 
 // Strong - Bold Paragraph
@@ -79,7 +84,12 @@ export function Small({
   className,
   ...props
 }: React.HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn("text-sm leading-6", className)} {...props} />;
+  return (
+    <p
+      className={cn("text-sm text-text-muted leading-6", className)}
+      {...props}
+    />
+  );
 }
 
 // Muted - Extra Small / Caption
@@ -88,7 +98,10 @@ export function Muted({
   ...props
 }: React.HTMLAttributes<HTMLParagraphElement>) {
   return (
-    <p className={cn("text-xs text-text leading-5", className)} {...props} />
+    <p
+      className={cn("text-xs text-text-muted leading-5", className)}
+      {...props}
+    />
   );
 }
 


### PR DESCRIPTION
The typography docs at https://design-system.e-infra.cz/docs/foundations/typography literally state:

> Lead text is larger and uses muted foreground color.
> Small text uses muted foreground and leading-6.
> Muted text is the smallest text style in the set.

Yet none of the three components actually carries a muted color class — `Muted` even hardcodes `text-text` (full foreground). Switching all three to `text-text-muted` (already used across the library) makes the code match the documented intent, with the docs table updated to match.

Co-authored-by: Kimi K3