### PR TITLE
feat(alert-dialog): accept variant and size props on Action and Cancel

### DIFF
--- a/lib/components/primitives/alert-dialog.tsx
+++ b/lib/components/primitives/alert-dialog.tsx
@@ -2,6 +2,8 @@
 
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
+import type { VariantProps } from "class-variance-authority";
+
 import { cn } from "../../lib/utils";
 import { buttonVariants } from "./button";
 
@@ -117,13 +119,21 @@ function AlertDialogDescription({
   );
 }
 
+type AlertDialogButtonProps = Pick<
+  VariantProps<typeof buttonVariants>,
+  "variant" | "size"
+>;
+
 function AlertDialogAction({
   className,
+  variant,
+  size,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  AlertDialogButtonProps) {
   return (
     <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), className)}
+      className={cn(buttonVariants({ variant, size }), className)}
       {...props}
     />
   );
@@ -131,11 +141,14 @@ function AlertDialogAction({
 
 function AlertDialogCancel({
   className,
+  variant = "outline",
+  size,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  AlertDialogButtonProps) {
   return (
     <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: "outline" }), className)}
+      className={cn(buttonVariants({ variant, size }), className)}
       {...props}
     />
   );


### PR DESCRIPTION
`AlertDialogAction` and `AlertDialogCancel` previously hardcoded their button styles (default / outline), so a destructive confirmation could only be styled by hand-overriding classes. They now accept `variant` and `size`, forwarded to `buttonVariants` — the same passthrough pattern as `PaginationLink`, and matching current shadcn/ui.

```tsx
<AlertDialogAction variant="error">Delete</AlertDialogAction>
```

No behavior change for existing callers.

Co-authored-by: Kimi K3