### PR TITLE
feat(stepper): support icons in step markers

### DIFF
--- a/docs/components/primitives/stepper.mdx
+++ b/docs/components/primitives/stepper.mdx
@@ -139,10 +139,10 @@ function StepperActions() {
 
 ### StepperHeader
 
-| Prop      | Type   | Default | Description                                                       |
-| --------- | ------ | ------- | ----------------------------------------------------------------- |
-| steps     | Step[] | -       | Array of step definitions with `label` and optional `description` |
-| className | string | -       | Additional CSS classes                                            |
+| Prop      | Type   | Default | Description                                                                  |
+| --------- | ------ | ------- | ---------------------------------------------------------------------------- |
+| steps     | Step[] | -       | Array of step definitions with `label`, optional `description`, and `icon`   |
+| className | string | -       | Additional CSS classes                                                       |
 
 ### StepperContent
 
@@ -239,6 +239,21 @@ function CustomFooterActions() {
   <StepperContent>{/* Your step content */}</StepperContent>
   <CustomFooterActions />
 </Stepper>;
+```
+
+### Step Icons
+
+Show an icon in each step marker instead of the step number. Any component accepting an optional `className` works — the stepper passes marker sizing to it:
+
+```tsx
+import { FileText, FileSearch, BookUser, CircleCheck } from "lucide-react";
+
+const steps = [
+  { label: "Publication Info", icon: FileText },
+  { label: "Duplicity Check", icon: FileSearch },
+  { label: "Authors", icon: BookUser },
+  { label: "Finish", icon: CircleCheck },
+];
 ```
 
 ### On Step Change Callback

--- a/lib/components/primitives/stepper.stories.tsx
+++ b/lib/components/primitives/stepper.stories.tsx
@@ -17,6 +17,7 @@ import { Input } from "./input";
 import { Label } from "./label";
 import { Textarea } from "./textarea";
 import { Button } from "./button";
+import { BookUser, CircleCheck, FileSearch, FileText } from "lucide-react";
 
 const meta = {
   title: "Primitives/Stepper",
@@ -307,6 +308,32 @@ export const WithCustomNavigation: Story = {
           <Step4Acknowledgements />
         </StepperContent>
         <CustomNavigationFooter />
+      </Stepper>
+    </div>
+  ),
+};
+
+const iconSteps = [
+  { label: "Publication Info", icon: FileText },
+  { label: "Duplicity Check", icon: FileSearch },
+  { label: "Authors", icon: BookUser },
+  { label: "Finish", icon: CircleCheck },
+];
+
+/**
+ * Steps can show an icon in their marker instead of the step number.
+ */
+export const WithIcons: Story = {
+  render: () => (
+    <div className="w-200">
+      <Stepper initialStep={1} totalSteps={iconSteps.length}>
+        <StepperHeader steps={iconSteps} />
+        <StepperContent>
+          <Step1PublicationInfo />
+          <Step2DuplicityCheck />
+          <Step3Authors />
+          <Step4Acknowledgements />
+        </StepperContent>
       </Stepper>
     </div>
   ),

--- a/lib/components/primitives/stepper.tsx
+++ b/lib/components/primitives/stepper.tsx
@@ -8,6 +8,7 @@ import { Button } from "./button";
 interface Step {
   label: string;
   description?: string;
+  icon?: React.ComponentType<{ className?: string }>;
 }
 
 interface StepperContextValue {
@@ -123,6 +124,7 @@ export function StepperHeader({ steps = [], className }: StepperHeaderProps) {
   const stepMarkerSize = 28;
   const stepItems = Array.from({ length: safeTotalSteps }, (_, index) => ({
     label: steps[index]?.label ?? `Step ${String(index + 1)}`,
+    icon: steps[index]?.icon,
   }));
   const currentStepLabel =
     stepItems[activeStepIndex]?.label ?? `Step ${String(activeStepIndex + 1)}`;
@@ -199,7 +201,11 @@ export function StepperHeader({ steps = [], className }: StepperHeaderProps) {
                             : "0 0 6px rgba(115, 112, 128, 0.38)",
                       }}
                     >
-                      {index + 1}
+                      {step.icon ? (
+                        <step.icon className="h-4 w-4" aria-hidden />
+                      ) : (
+                        index + 1
+                      )}
                     </button>
                   );
                 })}


### PR DESCRIPTION
Step markers currently always render the step number, so consumers cannot give steps a visual identity.

This adds an optional `icon` to `Step` (per the docs, steps are "step definitions with `label` and optional `description`"): when provided, the marker renders the icon instead of the number, keeping the existing label/accessibility wiring. Numbered markers remain the default, so this is fully backward compatible.

The icon type is `React.ComponentType<{ className?: string }>`. The stepper passes marker sizing via `className`.

Includes a Storybook story and a docs example.

Co-authored-by: Kimi K3 <noreply@moonshot.ai>