### PR TITLE
feat(stepper): controlled step prop and optional header navigation

### DIFF
--- a/docs/components/primitives/stepper.mdx
+++ b/docs/components/primitives/stepper.mdx
@@ -133,16 +133,18 @@ function StepperActions() {
 | Prop         | Type                   | Default | Description                                                                                                                         |
 | ------------ | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | children     | React.ReactNode        | -       | Step content and child components                                                                                                   |
-| initialStep  | number                 | `0`     | Starting step index                                                                                                                 |
+| initialStep  | number                 | `0`     | Starting step index (uncontrolled mode)                                                                                             |
+| step         | number                 | -       | Controlled current step (0-based). When set, the parent owns the step and receives updates through onStepChange                      |
 | totalSteps   | number                 | -       | Total number of steps. If omitted, it is inferred from Stepper direct children, so pass explicitly when your content count differs. |
 | onStepChange | (step: number) => void | -       | Callback when step changes                                                                                                          |
 
 ### StepperHeader
 
-| Prop      | Type   | Default | Description                                                                  |
-| --------- | ------ | ------- | ---------------------------------------------------------------------------- |
-| steps     | Step[] | -       | Array of step definitions with `label`, optional `description`, and `icon`   |
-| className | string | -       | Additional CSS classes                                                       |
+| Prop           | Type    | Default | Description                                                                    |
+| -------------- | ------- | ------- | ------------------------------------------------------------------------------ |
+| steps          | Step[]  | -       | Array of step definitions with `label`, optional `description`, and `icon`     |
+| className      | string  | -       | Additional CSS classes                                                         |
+| showNavigation | boolean | `true`  | Show the built-in Previous/Next buttons. Hide them when providing custom navigation |
 
 ### StepperContent
 
@@ -165,21 +167,22 @@ function StepperActions() {
 
 ## Controlled vs Uncontrolled
 
-The Stepper works as an uncontrolled component by default, managing its own internal state. You can also use it in a controlled manner by managing the step externally:
+The Stepper works as an uncontrolled component by default, managing its own internal state from `initialStep`. For full external control — e.g. when the step lives in a parent form, a store, or the URL — pass `step` together with `onStepChange` and hide the built-in header buttons in favor of your own navigation:
 
 ```tsx
 function ControlledStepper() {
   const [currentStep, setCurrentStep] = React.useState(0);
 
   return (
-    <Stepper initialStep={currentStep} onStepChange={setCurrentStep}>
-      <StepperHeader steps={steps} />
+    <Stepper
+      step={currentStep}
+      totalSteps={steps.length}
+      onStepChange={setCurrentStep}
+    >
+      <StepperHeader steps={steps} showNavigation={false} />
       <StepperContent>{/* Your step content */}</StepperContent>
-      <StepperFooter
-        onFinish={() => console.log("Finished")}
-        showDefaultButtons={false}
-      >
-        {/* Custom controls using currentStep */}
+      <StepperFooter showDefaultButtons={false}>
+        {/* Custom controls via useStepper() */}
       </StepperFooter>
     </Stepper>
   );
@@ -235,7 +238,7 @@ function CustomFooterActions() {
 }
 
 <Stepper totalSteps={steps.length}>
-  <StepperHeader steps={steps} />
+  <StepperHeader steps={steps} showNavigation={false} />
   <StepperContent>{/* Your step content */}</StepperContent>
   <CustomFooterActions />
 </Stepper>;

--- a/lib/components/primitives/stepper.stories.tsx
+++ b/lib/components/primitives/stepper.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
 import {
   Stepper,
   StepperContent,
@@ -197,14 +198,14 @@ export const WithInitialStep: Story = {
 };
 
 /**
- * Shows how to add optional custom actions in the footer while
- * keeping the header as the primary navigation.
+ * Shows how to add optional custom actions in the footer; the built-in
+ * header navigation is hidden so the controls are not duplicated.
  */
 export const WithCustomFooter: Story = {
   render: () => (
     <div className="w-200">
       <Stepper totalSteps={steps.length}>
-        <StepperHeader steps={steps} />
+        <StepperHeader steps={steps} showNavigation={false} />
         <StepperContent>
           <Step1PublicationInfo />
           <Step2DuplicityCheck />
@@ -300,7 +301,7 @@ export const WithCustomNavigation: Story = {
   render: () => (
     <div className="w-200">
       <Stepper totalSteps={steps.length}>
-        <StepperHeader steps={steps} />
+        <StepperHeader steps={steps} showNavigation={false} />
         <StepperContent>
           <Step1PublicationInfo />
           <Step2DuplicityCheck />
@@ -337,4 +338,30 @@ export const WithIcons: Story = {
       </Stepper>
     </div>
   ),
+};
+
+/**
+ * The parent owns the step via the step prop; the header navigation is
+ * hidden in favor of custom footer controls.
+ */
+export const ControlledExternally: Story = {
+  render: function ControlledStory() {
+    const [step, setStep] = useState(1);
+    return (
+      <div className="w-200">
+        <Stepper step={step} totalSteps={steps.length} onStepChange={setStep}>
+          <StepperHeader steps={steps} showNavigation={false} />
+          <StepperContent>
+            <Step1PublicationInfo />
+            <Step2DuplicityCheck />
+            <Step3Authors />
+            <Step4Acknowledgements />
+          </StepperContent>
+          <StepperFooter showDefaultButtons={false}>
+            <CustomFooterActions />
+          </StepperFooter>
+        </Stepper>
+      </div>
+    );
+  },
 };

--- a/lib/components/primitives/stepper.tsx
+++ b/lib/components/primitives/stepper.tsx
@@ -34,6 +34,7 @@ export function useStepper() {
 interface StepperProps {
   children: React.ReactNode;
   initialStep?: number;
+  step?: number;
   totalSteps?: number;
   onStepChange?: (step: number) => void;
 }
@@ -41,6 +42,7 @@ interface StepperProps {
 export function Stepper({
   children,
   initialStep = 0,
+  step: stepProp,
   totalSteps: totalStepsProp,
   onStepChange,
 }: StepperProps) {
@@ -49,47 +51,59 @@ export function Stepper({
     return Math.max(0, Math.min(step, maxIndex));
   }, []);
 
-  const [currentStep, setCurrentStep] = React.useState(initialStep);
+  const isControlled = stepProp !== undefined;
+  const [internalStep, setInternalStep] = React.useState(initialStep);
   const steps = React.Children.toArray(children);
   const totalSteps = Math.max(totalStepsProp ?? steps.length, 1);
+  const currentStep = clampStep(
+    isControlled ? stepProp : internalStep,
+    totalSteps
+  );
   const previousInitialStepRef = React.useRef(initialStep);
 
+  const changeStep = React.useCallback(
+    (step: number) => {
+      if (!isControlled) {
+        setInternalStep(step);
+      }
+      onStepChange?.(step);
+    },
+    [isControlled, onStepChange]
+  );
+
   const nextStep = React.useCallback(() => {
-    const next = clampStep(currentStep + 1, totalSteps);
-    setCurrentStep(next);
-    onStepChange?.(next);
-  }, [clampStep, currentStep, totalSteps, onStepChange]);
+    changeStep(clampStep(currentStep + 1, totalSteps));
+  }, [changeStep, clampStep, currentStep, totalSteps]);
 
   const previousStep = React.useCallback(() => {
-    const next = clampStep(currentStep - 1, totalSteps);
-    setCurrentStep(next);
-    onStepChange?.(next);
-  }, [clampStep, currentStep, totalSteps, onStepChange]);
+    changeStep(clampStep(currentStep - 1, totalSteps));
+  }, [changeStep, clampStep, currentStep, totalSteps]);
 
   const goToStep = React.useCallback(
     (step: number) => {
-      const validStep = clampStep(step, totalSteps);
-      setCurrentStep(validStep);
-      onStepChange?.(validStep);
+      changeStep(clampStep(step, totalSteps));
     },
-    [clampStep, totalSteps, onStepChange]
+    [changeStep, clampStep, totalSteps]
   );
 
   React.useEffect(() => {
-    setCurrentStep((prev) => {
+    if (isControlled) {
+      return;
+    }
+    setInternalStep((prev) => {
       const clamped = clampStep(prev, totalSteps);
       return prev === clamped ? prev : clamped;
     });
-  }, [clampStep, totalSteps]);
+  }, [clampStep, isControlled, totalSteps]);
 
   React.useEffect(() => {
-    if (previousInitialStepRef.current === initialStep) {
+    if (isControlled || previousInitialStepRef.current === initialStep) {
       return;
     }
 
     previousInitialStepRef.current = initialStep;
-    setCurrentStep(clampStep(initialStep, totalSteps));
-  }, [clampStep, initialStep, totalSteps]);
+    setInternalStep(clampStep(initialStep, totalSteps));
+  }, [clampStep, initialStep, isControlled, totalSteps]);
 
   return (
     <StepperContext.Provider
@@ -109,9 +123,14 @@ export function Stepper({
 interface StepperHeaderProps {
   steps?: Step[];
   className?: string;
+  showNavigation?: boolean;
 }
 
-export function StepperHeader({ steps = [], className }: StepperHeaderProps) {
+export function StepperHeader({
+  steps = [],
+  className,
+  showNavigation = true,
+}: StepperHeaderProps) {
   const { currentStep, previousStep, nextStep, goToStep, totalSteps } =
     useStepper();
   const safeTotalSteps = Math.max(totalSteps, 1);
@@ -147,20 +166,23 @@ export function StepperHeader({ steps = [], className }: StepperHeaderProps) {
         </p>
 
         <div className="flex w-full items-center justify-center gap-4 md:gap-10">
-          <div className="shrink-0">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={previousStep}
-              disabled={currentStep === 0}
-              className="gap-1.5 md:min-w-26"
-            >
-              <ChevronLeft className="h-3.5 w-3.5" />
-              Previous
-            </Button>
-          </div>
+          {showNavigation && (
+            <div className="shrink-0">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={previousStep}
+                disabled={currentStep === 0}
+                className="gap-1.5 md:min-w-26"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+                Previous
+              </Button>
+            </div>
+          )}
 
-          <div className="relative w-full max-w-lg">
+          {/* max-w-lg only balances against the flanking Previous/Next buttons */}
+          <div className={cn("relative w-full", showNavigation && "max-w-lg")}>
             <div className="relative">
               <div className="absolute left-3 right-3 top-1/2 h-2 -translate-y-1/2 rounded-full bg-border/80" />
               <div
@@ -214,18 +236,20 @@ export function StepperHeader({ steps = [], className }: StepperHeaderProps) {
             </div>
           </div>
 
-          <div className="shrink-0">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={nextStep}
-              disabled={currentStep === totalSteps - 1}
-              className="gap-1.5 md:min-w-26"
-            >
-              Next
-              <ChevronRight className="h-3.5 w-3.5" />
-            </Button>
-          </div>
+          {showNavigation && (
+            <div className="shrink-0">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={nextStep}
+                disabled={currentStep === totalSteps - 1}
+                className="gap-1.5 md:min-w-26"
+              >
+                Next
+                <ChevronRight className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
Two external-control gaps in the stepper, both backward-compatible:

1. **`step` on `Stepper` — controlled mode that can *veto* navigation.** The documented `initialStep` + `onStepChange` pattern works for mirroring state, but not for guarding transitions: an invalid click has already mutated internal state when `onStepChange` fires, and the re-sync effect is ref-guarded against unchanged `initialStep`, so the stepper stays on the rejected step with no way back. With a real `step` prop, `currentStep` is derived from the parent's state each render — keeping state unchanged cleanly rejects the transition. This is needed for wizards that gate steps (e.g. a final step locked until earlier ones validate). Uncontrolled behavior with `initialStep` is unchanged.

2. **`showNavigation` on `StepperHeader` — hide the built-in Previous/Next buttons.** The docs' own custom-navigation examples (`WithCustomFooter`, `WithCustomNavigation`, the Custom Footer snippet) render the built-in buttons and the custom controls on one screen. There is no consumer-side way to hide the header buttons; with this prop, `StepperFooter` children + `useStepper()` can own navigation without duplication.

The existing custom-navigation stories and docs examples are opted into `showNavigation={false}`. Includes a controlled Storybook story and updated docs.

Co-authored-by: Kimi K3 <noreply@moonshot.ai>