### PR TITLE
fix(stepper): progress fill protrudes past the final step marker

### DIFF
--- a/lib/components/primitives/stepper.tsx
+++ b/lib/components/primitives/stepper.tsx
@@ -120,6 +120,7 @@ export function StepperHeader({ steps = [], className }: StepperHeaderProps) {
   );
   const progressPercentage =
     safeTotalSteps > 1 ? (activeStepIndex / (safeTotalSteps - 1)) * 100 : 100;
+  const isLastStep = activeStepIndex === safeTotalSteps - 1;
   const stepMarkerSize = 28;
   const stepItems = Array.from({ length: safeTotalSteps }, (_, index) => ({
     label: steps[index]?.label ?? `Step ${String(index + 1)}`,
@@ -163,7 +164,7 @@ export function StepperHeader({ steps = [], className }: StepperHeaderProps) {
               <div
                 className="absolute left-3 top-1/2 h-2 -translate-y-1/2 rounded-full bg-primary transition-all"
                 style={{
-                  width: `calc(${String(progressPercentage)}% - ${String(progressPercentage / 100)} * ${String(stepMarkerSize)}px + ${String(stepMarkerSize)}px)`,
+                  width: `calc(${String(progressPercentage)}% - ${String(progressPercentage / 100)} * ${String(stepMarkerSize)}px + ${String(isLastStep ? 0 : stepMarkerSize)}px)`,
                 }}
               />
 


### PR DESCRIPTION
<img width="79" height="47" alt="image" src="https://github.com/user-attachments/assets/9d9bc607-9963-4bf8-8378-4e50f0e98c5b" />

At the final step the progress fill extends roughly 12px past the last marker: the fill starts at `left-3` while its width adds a `+stepMarkerSize` lead to `progress%`, so at 100% it ends up wider than the container.

This drops the lead only when the active step is the last one (`isLastStep`), leaving the mid-step behavior untouched.

Co-authored-by: Kimi K3 <noreply@moonshot.ai>